### PR TITLE
Removes ProjectVersion legacyFiles listing from packages

### DIFF
--- a/packages/com.vrchat.avatars/package.json
+++ b/packages/com.vrchat.avatars/package.json
@@ -1,34 +1,31 @@
 {
-  "name": "com.vrchat.avatars",
-  "displayName": "VRChat SDK - Avatars",
-  "version": "3.0.9",
-  "unity": "2019.4",
-  "description": "Our powerful Avatars 3.0 System",
-  "gitDependencies": {
-    "com.vrchat.base": "https://github.com/vrchat/packages.git?path=/packages/com.vrchat.base#3.0.9"
-  },
-  "author": {
-    "name": "VRChat",
-    "email": "developer@vrchat.com",
-    "url": "https://github.com/vrchat/packages"
-  },
-  "legacyFolders": {
-    "Assets\\VRCSDK": ""
-  },
-  "legacyFiles": {
-    "ProjectVersion.txt": ""
-  },
-  "url": "https://github.com/vrchat/packages.git?path=/packages/com.vrchat.avatars#3.0.9",
-  "samples": [
-    {
-      "displayName": "AV3 Demo Assets",
-      "description": "Basic AV3 Demo Assets",
-      "path": "Samples~/AV3 Demo Assets"
-    },
-    {
-      "displayName": "Robot Avatar",
-      "description": "Demo of Avatar Dynamics",
-      "path": "Samples~/Dynamics/Robot Avatar"
-    }
-  ]
+	"name" : "com.vrchat.avatars",
+	"displayName" : "VRChat SDK - Avatars",
+	"version" : "3.0.9",
+	"unity" : "2019.4",
+	"description" : "Our powerful Avatars 3.0 System",
+	"gitDependencies" : {
+		"com.vrchat.base" : "https://github.com/vrchat/packages.git?path=/packages/com.vrchat.base#3.0.9"
+	},
+	"author" : {
+		"name" : "VRChat",
+		"email" : "developer@vrchat.com",
+		"url" : "https://github.com/vrchat/packages"
+	},
+	"legacyFolders" : {
+		"Assets\\VRCSDK" : ""
+	},
+	"url" : "https://github.com/vrchat/packages.git?path=/packages/com.vrchat.avatars#3.0.9",
+	"samples" : [
+		{
+			"displayName" : "AV3 Demo Assets",
+			"description" : "Basic AV3 Demo Assets",
+			"path" : "Samples~/AV3 Demo Assets"
+		},
+		{
+			"displayName" : "Robot Avatar",
+			"description" : "Demo of Avatar Dynamics",
+			"path" : "Samples~/Dynamics/Robot Avatar"
+		}
+	]
 }

--- a/packages/com.vrchat.worlds/package.json
+++ b/packages/com.vrchat.worlds/package.json
@@ -1,37 +1,34 @@
 {
-  "name": "com.vrchat.worlds",
-  "displayName": "VRChat SDK - Worlds",
-  "version": "3.0.9",
-  "unity": "2019.4",
-  "description": "Tools for creating interactive VRChat worlds using Udon",
-  "dependencies": {
-    "com.unity.cinemachine": "2.8.0",
-    "com.unity.postprocessing": "3.1.1",
-    "com.unity.textmeshpro": "2.1.6"
-  },
-  "gitDependencies": {
-    "com.vrchat.base": "https://github.com/vrchat/packages.git?path=/packages/com.vrchat.base#3.0.9"
-  },
-  "author": {
-    "name": "VRChat",
-    "email": "developer@vrchat.com",
-    "url": "https://github.com/vrchat/packages"
-  },
-  "legacyFolders": {
-    "Assets\\VRCSDK": "",
-    "Assets\\Udon": "",
-    "Assets\\VRChat Examples": "",
-    "Packages\\com.vrchat.vrcsdk3": ""
-  },
-  "legacyFiles": {
-    "ProjectVersion.txt": ""
-  },
-  "url": "https://github.com/vrchat/packages.git?path=/packages/com.vrchat.worlds#3.0.9",
-  "samples": [
-    {
-      "displayName": "UdonExampleScene",
-      "description": "Basic Udon Examples for Learning",
-      "path": "Samples~/UdonExampleScene"
-    }
-  ]
+	"name" : "com.vrchat.worlds",
+	"displayName" : "VRChat SDK - Worlds",
+	"version" : "3.0.9",
+	"unity" : "2019.4",
+	"description" : "Tools for creating interactive VRChat worlds using Udon",
+	"dependencies" : {
+		"com.unity.cinemachine" : "2.8.0",
+		"com.unity.postprocessing" : "3.1.1",
+		"com.unity.textmeshpro" : "2.1.6"
+	},
+	"gitDependencies" : {
+		"com.vrchat.base" : "https://github.com/vrchat/packages.git?path=/packages/com.vrchat.base#3.0.9"
+	},
+	"author" : {
+		"name" : "VRChat",
+		"email" : "developer@vrchat.com",
+		"url" : "https://github.com/vrchat/packages"
+	},
+	"legacyFolders" : {
+		"Assets\\VRCSDK" : "",
+		"Assets\\Udon" : "",
+		"Assets\\VRChat Examples" : "",
+		"Packages\\com.vrchat.vrcsdk3" : ""
+	},
+	"url" : "https://github.com/vrchat/packages.git?path=/packages/com.vrchat.worlds#3.0.9",
+	"samples" : [
+		{
+			"displayName" : "UdonExampleScene",
+			"description" : "Basic Udon Examples for Learning",
+			"path" : "Samples~/UdonExampleScene"
+		}
+	]
 }


### PR DESCRIPTION
This makes it easier to migrate, Unity will know what the last actual version used was